### PR TITLE
Update coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,9 @@
 name: coverage
 
-on: push
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   codecov:
@@ -29,9 +32,7 @@ jobs:
       run: poetry install
       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
     - name: Test with pytest
-      run: |
-        poetry run pytest --cov=django_guid tests/ --verbose --color=yes --assert=plain --cov-report=xml
-        poetry run coverage report
+      run: poetry run pytest --cov=django_guid tests/ --verbose --assert=plain --cov-report=xml
     - name: Upload coverage
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,9 +1,10 @@
 name: Codecov
 
-on:
-  push:
-    branches:
-      - master
+on: push
+#on:
+#  push:
+#    branches:
+#      - master
 
 jobs:
   codecov:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,15 +11,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+    - uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3
+    - uses: snok/install-poetry@v1.0.0
+      with:
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+    - id: cached-poetry-dependencies
+      uses: actions/cache@v2
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-5
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install poetry
-        poetry install
+      run: poetry install
+      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
     - name: Test with pytest
       run: |
         poetry run pytest --cov=django_guid tests/ --verbose --color=yes --assert=plain --cov-report=xml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,29 +1,33 @@
-name: Codecov
+name: coverage
 
-on: push
-#on:
-#  push:
-#    branches:
-#      - master
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   codecov:
-    name: Code coverage
+    # ---------------------------------------------------
+    #    Documentation and examples can be found at
+    #      https://github.com/snok/install-poetry
+    # ---------------------------------------------------
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3
-    - uses: snok/install-poetry@v1.0.0
+        python-version: 3.9
+    - name: Install poetry
+      uses: snok/install-poetry@v1.0.0
       with:
         virtualenvs-create: true
         virtualenvs-in-project: true
-    - id: cached-poetry-dependencies
+    - name: Load cached venv
+      id: cached-poetry-dependencies
       uses: actions/cache@v2
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-5
+        key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
     - name: Install dependencies
       run: poetry install
       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,9 +1,6 @@
 name: coverage
 
-on:
-  push:
-    branches:
-      - master
+on: push
 
 jobs:
   codecov:
@@ -35,12 +32,8 @@ jobs:
       run: |
         poetry run pytest --cov=django_guid tests/ --verbose --color=yes --assert=plain --cov-report=xml
         poetry run coverage report
-    - name: Upload coverage to Codecov
+    - name: Upload coverage
       uses: codecov/codecov-action@v1
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella
-        yml: ./codecov.yml
         fail_ci_if_error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v2
         with:
-          python-version: "3"
+          python-version: 3
       - name: Load cached wheels
         uses: actions/cache@v2
         with:
@@ -48,10 +48,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Use Poetry
+      - name: Install poetry
         uses: snok/install-poetry@v1.0.0
         with:
           virtualenvs-create: true
+          virtualenvs-in-project: true
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v2
@@ -59,16 +60,12 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-5
       - name: Install dependencies
-        run: |
-          source $HOME/.poetry/env
-          poetry install
+        run: poetry install
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
       - name: Install django ${{ matrix.django-version }}
         run: |
-          source $HOME/.poetry/env
           poetry run pip install "Django==${{ matrix.django-version }}"
       - name: Run tests
         run: |
-          source $HOME/.poetry/env
           poetry run pytest --cov=django_guid tests/
           poetry run coverage report


### PR DESCRIPTION
Adds install-poetry action for coverage job.

Removes the `CODECOV_TOKEN` parts of the codecov action in the coverage run, as it is not required to explicitly state as long as it exists in the repos secrets (see https://github.com/codecov/codecov-action)