### PR TITLE
Rework settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,6 +134,7 @@ Package settings are added in your ``settings.py``:
         'EXPOSE_HEADER': True,
         'INTEGRATIONS': [],
         'IGNORE_URLS': [],
+        'UUID_LENGTH': 32,
     }
 
 
@@ -175,6 +176,11 @@ Package settings are added in your ``settings.py``:
         URL endpoints where the middleware will be disabled. You can put your health check endpoints here.
 
     Default: []
+
+* :code:`UUID_LENGTH`
+        Lets you optionally trim the length of the package generated UUIDs.
+
+    Default: 32
 
 *************
 Configuration

--- a/demoproj/settings.py
+++ b/demoproj/settings.py
@@ -87,7 +87,7 @@ TEMPLATES = [
 
 # fmt: off
 
-# Non required DJANGO_GUID settings (Set to default values here)
+# OBS: No setting in Django GUID is required. These are example settings.
 DJANGO_GUID = {
     'GUID_HEADER_NAME': 'Correlation-ID',
     'VALIDATE_GUID': True,

--- a/django_guid/apps.py
+++ b/django_guid/apps.py
@@ -9,3 +9,6 @@ class DjangoGuidConfig(AppConfig):
         In order to avoid circular imports we import signals here.
         """
         from django_guid import signals  # noqa F401
+        from django_guid.config import settings
+
+        settings.validate()

--- a/django_guid/config.py
+++ b/django_guid/config.py
@@ -8,8 +8,6 @@ from django.utils.inspect import func_accepts_kwargs
 
 class IntegrationSettings:
     def __init__(self, integration_settings: dict) -> None:
-        if integration_settings is None:
-            integration_settings = {}
         self.settings = integration_settings
 
     def validate(self):
@@ -71,8 +69,8 @@ class Settings:
             raise ImproperlyConfigured('IGNORE_URLS must be an array')
         if not all(isinstance(url, str) for url in self.settings.get('IGNORE_URLS', [])):
             raise ImproperlyConfigured('IGNORE_URLS must be an array of strings')
-        if not isinstance(self.uuid_length, int):
-            raise ImproperlyConfigured('UUID_LENGTH must be an integer.')
+        if type(self.uuid_length) is not int or not 1 <= self.uuid_length <= 32:
+            raise ImproperlyConfigured('UUID_LENGTH must be an integer and be between 1-32')
 
         self._validate_and_setup_integrations()
 
@@ -92,14 +90,14 @@ class Settings:
                 # Make sure the methods are callable
                 if not callable(method):
                     raise ImproperlyConfigured(
-                        f'Integration method `{name}` needs to be made callable for `{integration.identifier}`.'
+                        f'Integration method `{name}` needs to be made callable for `{integration.identifier}`'
                     )
 
                 # Make sure the method takes kwargs
                 if name in ['run', 'cleanup'] and not func_accepts_kwargs(method):
                     raise ImproperlyConfigured(
                         f'Integration method `{name}` must '
-                        f'accept keyword arguments (**kwargs) for `{integration.identifier}`.'
+                        f'accept keyword arguments (**kwargs) for `{integration.identifier}`'
                     )
 
             # Run validate method

--- a/django_guid/config.py
+++ b/django_guid/config.py
@@ -1,63 +1,86 @@
-from typing import List
+# flake8: noqa: D102
+from typing import List, Union
 
 from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.inspect import func_accepts_kwargs
 
-from django_guid.integrations import Integration
+
+class IntegrationSettings:
+    def __init__(self, integration_settings: dict) -> None:
+        if integration_settings is None:
+            integration_settings = {}
+        self.settings = integration_settings
+
+    def validate(self):
+        pass
 
 
 class Settings:
-    """
-    Settings for django_guid read from the Django settings in `settings.py`.
-
-    Inspired by django-auth-adfs from @jobec
-    """
-
     def __init__(self) -> None:
-        self.GUID_HEADER_NAME = 'Correlation-ID'
-        self.VALIDATE_GUID = True
-        self.RETURN_HEADER = True
-        self.EXPOSE_HEADER = True
-        self.INTEGRATIONS: List[Integration] = []
-        self.IGNORE_URLS: List[str] = []
-
         if hasattr(django_settings, 'DJANGO_GUID'):
-            _settings = django_settings.DJANGO_GUID
+            self.settings = django_settings.DJANGO_GUID
+        else:
+            self.settings = {}
 
-            # Set user settings if provided
-            for setting, value in _settings.items():
-                if hasattr(self, setting):
-                    setattr(self, setting, value)
-                else:
-                    raise ImproperlyConfigured(f'{setting} is not a valid setting for django_guid')
+    @property
+    def guid_header_name(self) -> str:
+        return self.settings.get('GUID_HEADER_NAME', 'Correlation-ID')
 
-            if not isinstance(self.VALIDATE_GUID, bool):
-                raise ImproperlyConfigured('VALIDATE_GUID must be a boolean')
-            if not isinstance(self.GUID_HEADER_NAME, str):
-                raise ImproperlyConfigured('GUID_HEADER_NAME must be a string')  # Note: Case insensitive
-            if not isinstance(self.RETURN_HEADER, bool):
-                raise ImproperlyConfigured('RETURN_HEADER must be a boolean')
-            if not isinstance(self.EXPOSE_HEADER, bool):
-                raise ImproperlyConfigured('EXPOSE_HEADER must be a boolean')
-            if not isinstance(self.INTEGRATIONS, (list, tuple)):
-                raise ImproperlyConfigured('INTEGRATIONS must be an array')
-            if not isinstance(self.IGNORE_URLS, (list, tuple)):
-                raise ImproperlyConfigured('IGNORE_URLS must be an array')
+    @property
+    def return_header(self) -> bool:
+        return self.settings.get('RETURN_HEADER', True)
 
-            if not all(isinstance(url, str) for url in self.IGNORE_URLS):
-                raise ImproperlyConfigured('IGNORE_URLS must be an array of strings')
-            # Note: stripping the '/' from the beginning and end of the path of the URLS,
-            # this is since some people would write a path as "/path/one/two/" while others would write "path/one/two"
-            self.IGNORE_URLS = list({url.strip('/') for url in self.IGNORE_URLS})
+    @property
+    def expose_header(self) -> bool:
+        return self.settings.get('EXPOSE_HEADER', True)
 
-            self._validate_and_setup_integrations()
+    @property
+    def ignore_urls(self) -> List[str]:
+        return list({url.strip('/') for url in self.settings.get('IGNORE_URLS', [])})
+
+    @property
+    def validate_guid(self) -> bool:
+        return self.settings.get('VALIDATE_GUID', True)
+
+    @property
+    def integrations(self) -> Union[list, tuple]:
+        return self.settings.get('INTEGRATIONS', [])
+
+    @property
+    def integration_settings(self):
+        return IntegrationSettings({integration.identifier: integration for integration in self.integrations})
+
+    @property
+    def uuid_length(self):
+        return self.settings.get('UUID_LENGTH', 32)
+
+    def validate(self):
+        if not isinstance(self.validate_guid, bool):
+            raise ImproperlyConfigured('VALIDATE_GUID must be a boolean')
+        if not isinstance(self.guid_header_name, str):
+            raise ImproperlyConfigured('GUID_HEADER_NAME must be a string')  # Note: Case insensitive
+        if not isinstance(self.return_header, bool):
+            raise ImproperlyConfigured('RETURN_HEADER must be a boolean')
+        if not isinstance(self.expose_header, bool):
+            raise ImproperlyConfigured('EXPOSE_HEADER must be a boolean')
+        if not isinstance(self.integrations, (list, tuple)):
+            raise ImproperlyConfigured('INTEGRATIONS must be an array')
+        if not isinstance(self.settings.get('IGNORE_URLS', []), (list, tuple)):
+            raise ImproperlyConfigured('IGNORE_URLS must be an array')
+        if not all(isinstance(url, str) for url in self.settings.get('IGNORE_URLS', [])):
+            raise ImproperlyConfigured('IGNORE_URLS must be an array of strings')
+        if not isinstance(self.uuid_length, int):
+            raise ImproperlyConfigured('UUID_LENGTH must be an integer.')
+
+        self._validate_and_setup_integrations()
 
     def _validate_and_setup_integrations(self) -> None:
         """
         Validate the INTEGRATIONS settings and verify each integration
         """
-        for integration in self.INTEGRATIONS:
+        self.integration_settings.validate()
+        for integration in self.integrations:
 
             # Make sure all integration methods are callable
             for method, name in [

--- a/django_guid/config.py
+++ b/django_guid/config.py
@@ -41,6 +41,7 @@ class Settings:
 
     @property
     def validate_guid(self) -> bool:
+        print('---', self.settings.get('VALIDATE_GUID'))
         return self.settings.get('VALIDATE_GUID', True)
 
     @property

--- a/django_guid/middleware.py
+++ b/django_guid/middleware.py
@@ -29,7 +29,7 @@ def process_incoming_request(request: HttpRequest) -> None:
         guid.set(get_id_from_header(request))
 
         # Run all integrations
-        for integration in settings.INTEGRATIONS:
+        for integration in settings.integrations:
             logger.debug('Running integration: `%s`', integration.identifier)
             integration.run(guid=guid.get())
     return
@@ -40,13 +40,13 @@ def process_outgoing_request(response: HttpResponse, request: HttpRequest) -> No
     Process an outgoing request. This function is called after the view and before later middleware.
     """
     if not ignored_url(request=request):
-        if settings.RETURN_HEADER:
-            response[settings.GUID_HEADER_NAME] = guid.get()  # Adds the GUID to the response header
-            if settings.EXPOSE_HEADER:
-                response['Access-Control-Expose-Headers'] = settings.GUID_HEADER_NAME
+        if settings.return_header:
+            response[settings.guid_header_name] = guid.get()  # Adds the GUID to the response header
+            if settings.expose_header:
+                response['Access-Control-Expose-Headers'] = settings.guid_header_name
 
         # Run tear down for all the integrations
-        for integration in settings.INTEGRATIONS:
+        for integration in settings.integrations:
             logger.debug('Running tear down for integration: `%s`', integration.identifier)
             integration.cleanup()
     return

--- a/django_guid/utils.py
+++ b/django_guid/utils.py
@@ -1,6 +1,6 @@
 import logging
 import uuid
-from typing import Union
+from typing import Optional, Union
 
 from django.http import HttpRequest, HttpResponse
 
@@ -59,12 +59,14 @@ def ignored_url(request: Union[HttpRequest, HttpResponse]) -> bool:
     return request.get_full_path().strip('/') in settings.ignore_urls
 
 
-def generate_guid(uuid_length: int = settings.uuid_length) -> str:
+def generate_guid(uuid_length: Optional[int] = None) -> str:
     """
     Generates an UUIDv4/GUID as a string.
 
     :return: GUID
     """
+    if uuid_length is None:
+        return uuid.uuid4().hex[: settings.uuid_length]
     return uuid.uuid4().hex[:uuid_length]
 
 

--- a/django_guid/utils.py
+++ b/django_guid/utils.py
@@ -15,8 +15,8 @@ def get_correlation_id_from_header(request: HttpRequest) -> str:
     :param request: HttpRequest object
     :return: GUID
     """
-    given_guid = str(request.headers.get(settings.GUID_HEADER_NAME))
-    if not settings.VALIDATE_GUID:
+    given_guid = str(request.headers.get(settings.guid_header_name))
+    if not settings.validate_guid:
         logger.debug('Returning ID from header without validating it as a GUID')
         return given_guid
     elif validate_guid(given_guid):
@@ -36,15 +36,15 @@ def get_id_from_header(request: HttpRequest) -> str:
     :param request: HttpRequest object
     :return: GUID
     """
-    header: str = request.headers.get(settings.GUID_HEADER_NAME)  # Case insensitive headers.get added in Django2.2
+    header: str = request.headers.get(settings.guid_header_name)  # Case insensitive headers.get added in Django2.2
     if header:
-        logger.info('%s found in the header: %s', settings.GUID_HEADER_NAME, header)
+        logger.info('%s found in the header: %s', settings.guid_header_name, header)
         request.correlation_id = get_correlation_id_from_header(request)
     else:
         request.correlation_id = generate_guid()
         logger.info(
             'Header `%s` was not found in the incoming request. Generated new GUID: %s',
-            settings.GUID_HEADER_NAME,
+            settings.guid_header_name,
             request.correlation_id,
         )
     return request.correlation_id
@@ -56,16 +56,16 @@ def ignored_url(request: Union[HttpRequest, HttpResponse]) -> bool:
 
     :return: Boolean
     """
-    return request.get_full_path().strip('/') in settings.IGNORE_URLS
+    return request.get_full_path().strip('/') in settings.ignore_urls
 
 
-def generate_guid() -> str:
+def generate_guid(uuid_length: int = settings.uuid_length) -> str:
     """
     Generates an UUIDv4/GUID as a string.
 
     :return: GUID
     """
-    return uuid.uuid4().hex
+    return uuid.uuid4().hex[:uuid_length]
 
 
 def validate_guid(original_guid: str) -> bool:

--- a/docs/README_PYPI.rst
+++ b/docs/README_PYPI.rst
@@ -119,6 +119,7 @@ Package settings are added in your ``settings.py``:
         'EXPOSE_HEADER': True,
         'INTEGRATIONS': [],
         'IGNORE_URLS': [],
+        'UUID_LENGTH': 32,
     }
 
 
@@ -160,6 +161,11 @@ Package settings are added in your ``settings.py``:
         URL endpoints where the middleware will be disabled. You can put your health check endpoints here.
 
     Default: []
+
+* :code:`UUID_LENGTH`
+        Lets you optionally trim the length of the package generated UUIDs.
+
+    Default: 32
 
 *************
 Configuration

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -13,6 +13,7 @@ Default settings are shown below:
         'RETURN_HEADER': True,
         'EXPOSE_HEADER': True,
         'INTEGRATIONS': [],
+        'UUID_LENGTH': 32,
     }
 
 
@@ -71,3 +72,12 @@ IGNORE_URLS
 * **Type**: ``list``
 
 URL endpoints where the middleware will be disabled. You can put your health check endpoints here.
+
+UUID_LENGTH
+-----------
+* **Default**: ``32``
+* **Type**: ``int``
+
+If a full UUID hex is too long for you, this settings lets you specify the length you wish to use.
+The chance of collision in a UUID is so low, that most systems will get away with a lot
+fewer than 32 characters.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ def two_unique_uuid4():
 
 
 @pytest.fixture
-def mock_uuid_two_unique(monkeypatch, mocker, two_unique_uuid4):
+def mock_uuid_two_unique(mocker, two_unique_uuid4):
     mocker.patch.object(
         uuid.UUID,
         'hex',

--- a/tests/functional/test_async_middleware.py
+++ b/tests/functional/test_async_middleware.py
@@ -1,4 +1,8 @@
 import asyncio
+from copy import deepcopy
+
+from django.conf import settings as django_settings
+from django.test import override_settings
 
 import pytest
 
@@ -61,15 +65,15 @@ async def test_ignored_url(async_client, caplog, monkeypatch):
     :param caplog: Caplog fixture
     :param monkeypatch: Monkeypatch for django settings
     """
-    from django_guid.config import settings as guid_settings
-
-    monkeypatch.setattr(guid_settings, 'IGNORE_URLS', {'no-guid'})  # Same as it would be after config conversion
-    await async_client.get('/no-guid')
-    # No log message should have a GUID, aka `None` on index 1.
-    expected = [
-        ('async middleware called', None),
-        ('This log message should NOT have a GUID - the URL is in IGNORE_URLS', None),
-        ('Some warning in a function', None),
-        ('Received signal `request_finished`, clearing guid', None),
-    ]
-    assert [(x.message, x.correlation_id) for x in caplog.records] == expected
+    mocked_settings = deepcopy(django_settings.DJANGO_GUID)
+    mocked_settings['IGNORE_URLS'] = {'no-guid'}
+    with override_settings(**mocked_settings):
+        await async_client.get('/no-guid')
+        # No log message should have a GUID, aka `None` on index 1.
+        expected = [
+            ('async middleware called', None),
+            ('This log message should NOT have a GUID - the URL is in IGNORE_URLS', None),
+            ('Some warning in a function', None),
+            ('Received signal `request_finished`, clearing guid', None),
+        ]
+        assert [(x.message, x.correlation_id) for x in caplog.records] == expected

--- a/tests/functional/test_integration_base_class.py
+++ b/tests/functional/test_integration_base_class.py
@@ -89,15 +89,15 @@ def test_non_callable_methods(monkeypatch, subtests):
     to_test = [
         {
             'function_name': 'cleanup',
-            'error': 'Integration method `cleanup` needs to be made callable for `SentryIntegration`.',
+            'error': 'Integration method `cleanup` needs to be made callable for `SentryIntegration`',
         },
         {
             'function_name': 'run',
-            'error': 'Integration method `run` needs to be made callable for `SentryIntegration`.',
+            'error': 'Integration method `run` needs to be made callable for `SentryIntegration`',
         },
         {
             'function_name': 'setup',
-            'error': 'Integration method `setup` needs to be made callable for `SentryIntegration`.',
+            'error': 'Integration method `setup` needs to be made callable for `SentryIntegration`',
         },
     ]
 

--- a/tests/functional/test_sentry_integration.py
+++ b/tests/functional/test_sentry_integration.py
@@ -1,34 +1,37 @@
+from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
 
 import pytest
 
 
-def test_sentry_integration(client, monkeypatch, caplog, mocker):
+def test_sentry_integration(client, caplog, mocker):
     """
     Tests the sentry integration
     """
     from sentry_sdk.scope import Scope
 
-    from django_guid.config import settings as guid_settings
     from django_guid.integrations import SentryIntegration
 
-    monkeypatch.setattr(guid_settings, 'INTEGRATIONS', [SentryIntegration()])
-    mock_scope = mocker.patch.object(Scope, 'set_tag')
+    mocked_settings = django_settings.DJANGO_GUID
+    mocked_settings['INTEGRATIONS'] = [SentryIntegration()]
+    with override_settings(DJANGO_GUID=mocked_settings):
+        mock_scope = mocker.patch.object(Scope, 'set_tag')
 
-    client.get('/api', **{'HTTP_Correlation-ID': '97c304252fd14b25b72d6aee31565842'})
-    expected = [
-        (None, 'sync middleware called'),
-        (None, 'Correlation-ID found in the header: 97c304252fd14b25b72d6aee31565842'),
-        (None, '97c304252fd14b25b72d6aee31565842 is a valid GUID'),
-        ('97c304252fd14b25b72d6aee31565842', 'Running integration: `SentryIntegration`'),
-        ('97c304252fd14b25b72d6aee31565842', 'Setting Sentry transaction_id to 97c304252fd14b25b72d6aee31565842'),
-        ('97c304252fd14b25b72d6aee31565842', 'This is a DRF view log, and should have a GUID.'),
-        ('97c304252fd14b25b72d6aee31565842', 'Some warning in a function'),
-        ('97c304252fd14b25b72d6aee31565842', 'Running tear down for integration: `SentryIntegration`'),
-        ('97c304252fd14b25b72d6aee31565842', 'Received signal `request_finished`, clearing guid'),
-    ]
-    mock_scope.assert_called_with('transaction_id', '97c304252fd14b25b72d6aee31565842')
-    assert [(x.correlation_id, x.message) for x in caplog.records] == expected
+        client.get('/api', **{'HTTP_Correlation-ID': '97c304252fd14b25b72d6aee31565842'})
+        expected = [
+            (None, 'sync middleware called'),
+            (None, 'Correlation-ID found in the header: 97c304252fd14b25b72d6aee31565842'),
+            (None, '97c304252fd14b25b72d6aee31565842 is a valid GUID'),
+            ('97c304252fd14b25b72d6aee31565842', 'Running integration: `SentryIntegration`'),
+            ('97c304252fd14b25b72d6aee31565842', 'Setting Sentry transaction_id to 97c304252fd14b25b72d6aee31565842'),
+            ('97c304252fd14b25b72d6aee31565842', 'This is a DRF view log, and should have a GUID.'),
+            ('97c304252fd14b25b72d6aee31565842', 'Some warning in a function'),
+            ('97c304252fd14b25b72d6aee31565842', 'Running tear down for integration: `SentryIntegration`'),
+            ('97c304252fd14b25b72d6aee31565842', 'Received signal `request_finished`, clearing guid'),
+        ]
+        mock_scope.assert_called_with('transaction_id', '97c304252fd14b25b72d6aee31565842')
+        assert [(x.correlation_id, x.message) for x in caplog.records] == expected
 
 
 def test_sentry_validation(client, monkeypatch):
@@ -43,6 +46,7 @@ def test_sentry_validation(client, monkeypatch):
     from django_guid.integrations import SentryIntegration
 
     # Mock away the sentry_sdk dependency
+    backup = sys.modules['sentry_sdk']
     sys.modules['sentry_sdk'] = None
 
     monkeypatch.setattr(settings, 'DJANGO_GUID', {'INTEGRATIONS': [SentryIntegration()]})
@@ -51,4 +55,6 @@ def test_sentry_validation(client, monkeypatch):
         match='The package `sentry-sdk` is required for extending your tracing IDs to Sentry. '
         'Please run `pip install sentry-sdk` if you wish to include this integration.',
     ):
-        Settings()
+        Settings().validate()
+    # Put it back in - otherwise a bunch of downstream tests break
+    sys.modules['sentry_sdk'] = backup

--- a/tests/functional/test_sentry_integration.py
+++ b/tests/functional/test_sentry_integration.py
@@ -1,23 +1,30 @@
-from django.conf import settings as django_settings
+import sys
+
 from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
 
 import pytest
+from sentry_sdk.scope import Scope
+
+from django_guid.config import Settings
+from django_guid.integrations import SentryIntegration
+
+mocked_settings = {
+    'GUID_HEADER_NAME': 'Correlation-ID',
+    'VALIDATE_GUID': True,
+    'INTEGRATIONS': [SentryIntegration()],
+    'IGNORE_URLS': ['no-guid'],
+}
 
 
-def test_sentry_integration(client, caplog, mocker):
+def test_sentry_integration(client, caplog, mocker, monkeypatch):
     """
     Tests the sentry integration
     """
-    from sentry_sdk.scope import Scope
-
-    from django_guid.integrations import SentryIntegration
-
-    mocked_settings = django_settings.DJANGO_GUID
-    mocked_settings['INTEGRATIONS'] = [SentryIntegration()]
+    mock_scope = mocker.patch.object(Scope, 'set_tag')
     with override_settings(DJANGO_GUID=mocked_settings):
-        mock_scope = mocker.patch.object(Scope, 'set_tag')
-
+        settings = Settings()
+        monkeypatch.setattr('django_guid.middleware.settings', settings)
         client.get('/api', **{'HTTP_Correlation-ID': '97c304252fd14b25b72d6aee31565842'})
         expected = [
             (None, 'sync middleware called'),
@@ -34,27 +41,25 @@ def test_sentry_integration(client, caplog, mocker):
         assert [(x.correlation_id, x.message) for x in caplog.records] == expected
 
 
-def test_sentry_validation(client, monkeypatch):
+def test_sentry_validation(client):
     """
     Tests that the package handles multiple header values by defaulting to one and logging a warning.
     """
-    import sys
-
-    from django.conf import settings
-
-    from django_guid.config import Settings
-    from django_guid.integrations import SentryIntegration
 
     # Mock away the sentry_sdk dependency
-    backup = sys.modules['sentry_sdk']
-    sys.modules['sentry_sdk'] = None
+    backup = None
+    if 'sentry_sdk' in sys.modules:
+        backup = sys.modules['sentry_sdk']
+        sys.modules['sentry_sdk'] = None
 
-    monkeypatch.setattr(settings, 'DJANGO_GUID', {'INTEGRATIONS': [SentryIntegration()]})
-    with pytest.raises(
-        ImproperlyConfigured,
-        match='The package `sentry-sdk` is required for extending your tracing IDs to Sentry. '
-        'Please run `pip install sentry-sdk` if you wish to include this integration.',
-    ):
-        Settings().validate()
+    with override_settings(DJANGO_GUID=mocked_settings):
+        with pytest.raises(
+            ImproperlyConfigured,
+            match='The package `sentry-sdk` is required for extending your tracing IDs to Sentry. '
+            'Please run `pip install sentry-sdk` if you wish to include this integration.',
+        ):
+            Settings().validate()
+
     # Put it back in - otherwise a bunch of downstream tests break
-    sys.modules['sentry_sdk'] = backup
+    if backup:
+        sys.modules['sentry_sdk'] = backup

--- a/tests/functional/test_set_get_del_context.py
+++ b/tests/functional/test_set_get_del_context.py
@@ -13,7 +13,7 @@ async def test_api(async_client, caplog, mock_uuid):
         ),
         ('Current GUID: 704ae5472cae4f8daa8f2cc5a5a8mock', '704ae5472cae4f8daa8f2cc5a5a8mock'),
         (
-            'Changing the guid ContextVar from 704ae5472cae4f8daa8f2cc5a5a8mock to ' 'another guid',
+            'Changing the guid ContextVar from 704ae5472cae4f8daa8f2cc5a5a8mock to another guid',
             '704ae5472cae4f8daa8f2cc5a5a8mock',
         ),
         ('Current GUID: another guid', 'another guid'),

--- a/tests/functional/test_sync_middleware.py
+++ b/tests/functional/test_sync_middleware.py
@@ -1,4 +1,8 @@
+from copy import deepcopy
+
+from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
 
 import pytest
 
@@ -68,132 +72,132 @@ def test_request_with_invalid_correlation_id(client, caplog, mock_uuid):
     assert response['Correlation-ID'] == '704ae5472cae4f8daa8f2cc5a5a8mock'
 
 
-def test_request_with_invalid_correlation_id_without_validation(client, caplog, monkeypatch):
+def test_request_with_invalid_correlation_id_without_validation(client, caplog):
     """
     Tests that a request with an invalid GUID is replaced when VALIDATE_GUID is False.
     :param client: Django client
     :param caplog: Caplog fixture
-    :param monkeypatch: Monkeypatch for django settings
     """
-    from django_guid.config import settings as guid_settings
+    mocked_settings = django_settings.DJANGO_GUID
+    mocked_settings['VALIDATE_GUID'] = False
+    with override_settings(DJANGO_GUID=mocked_settings):
+        client.get('/', **{'HTTP_Correlation-ID': 'bad-guid'})
+        expected = [
+            ('sync middleware called', None),
+            ('Correlation-ID found in the header: bad-guid', None),
+            ('Returning ID from header without validating it as a GUID', None),
+            ('This log message should have a GUID', 'bad-guid'),
+            ('Some warning in a function', 'bad-guid'),
+            ('Received signal `request_finished`, clearing guid', 'bad-guid'),
+        ]
+        assert [(x.message, x.correlation_id) for x in caplog.records] == expected
 
-    monkeypatch.setattr(guid_settings, 'VALIDATE_GUID', False)
-    client.get('/', **{'HTTP_Correlation-ID': 'bad-guid'})
-    expected = [
-        ('sync middleware called', None),
-        ('Correlation-ID found in the header: bad-guid', None),
-        ('Returning ID from header without validating it as a GUID', None),
-        ('This log message should have a GUID', 'bad-guid'),
-        ('Some warning in a function', 'bad-guid'),
-        ('Received signal `request_finished`, clearing guid', 'bad-guid'),
-    ]
-    assert [(x.message, x.correlation_id) for x in caplog.records] == expected
 
-
-def test_no_return_header_and_drf_url(client, caplog, monkeypatch, mock_uuid):
+def test_no_return_header_and_drf_url(client, caplog, mock_uuid):
     """
     Tests that it does not return the GUID if RETURN_HEADER is false.
     This test also tests a DRF response, just to confirm everything works in both worlds.
     """
-    from django_guid.config import settings as guid_settings
+    mocked_settings = django_settings.DJANGO_GUID
+    mocked_settings['RETURN_HEADER'] = False
+    with override_settings(DJANGO_GUID=mocked_settings):
+        response = client.get('/api')
+        expected = [
+            ('sync middleware called', None),
+            (
+                'Header `Correlation-ID` was not found in the incoming request. '
+                'Generated new GUID: 704ae5472cae4f8daa8f2cc5a5a8mock',
+                None,
+            ),
+            ('This is a DRF view log, and should have a GUID.', '704ae5472cae4f8daa8f2cc5a5a8mock'),
+            ('Some warning in a function', '704ae5472cae4f8daa8f2cc5a5a8mock'),
+            ('Received signal `request_finished`, clearing guid', '704ae5472cae4f8daa8f2cc5a5a8mock'),
+        ]
+        assert [(x.message, x.correlation_id) for x in caplog.records] == expected
+        assert not response.get('Correlation-ID')
 
-    monkeypatch.setattr(guid_settings, 'RETURN_HEADER', False)
-    response = client.get('/api')
-    expected = [
-        ('sync middleware called', None),
-        (
-            'Header `Correlation-ID` was not found in the incoming request. '
-            'Generated new GUID: 704ae5472cae4f8daa8f2cc5a5a8mock',
-            None,
-        ),
-        ('This is a DRF view log, and should have a GUID.', '704ae5472cae4f8daa8f2cc5a5a8mock'),
-        ('Some warning in a function', '704ae5472cae4f8daa8f2cc5a5a8mock'),
-        ('Received signal `request_finished`, clearing guid', '704ae5472cae4f8daa8f2cc5a5a8mock'),
-    ]
-    assert [(x.message, x.correlation_id) for x in caplog.records] == expected
-    assert not response.get('Correlation-ID')
 
-
-def test_no_expose_header_return_header_true(client, monkeypatch, mock_uuid):
+def test_no_expose_header_return_header_true(client):
     """
     Tests that it does not return the Access-Control-Allow-Origin when EXPOSE_HEADER is set to False
     and RETURN_HEADER is True
     """
-    from django_guid.config import settings as guid_settings
+    mocked_settings = django_settings.DJANGO_GUID
+    mocked_settings['EXPOSE_HEADER'] = False
+    mocked_settings['RETURN_HEADER'] = True
+    with override_settings(DJANGO_GUID=mocked_settings):
+        response = client.get('/api')
+        assert not response.get('Access-Control-Expose-Headers')
 
-    monkeypatch.setattr(guid_settings, 'EXPOSE_HEADER', False)
-    response = client.get('/api')
-    assert not response.get('Access-Control-Expose-Headers')
 
-
-def test_expose_header_return_header_true(client, monkeypatch, mock_uuid):
+def test_expose_header_return_header_true(client):
     """
     Tests that it does return the Access-Control-Allow-Origin when EXPOSE_HEADER is set to True
     and RETURN_HEADER is True
     """
-    from django_guid.config import settings as guid_settings
+    mocked_settings = django_settings.DJANGO_GUID
+    mocked_settings['EXPOSE_HEADER'] = True
+    with override_settings(DJANGO_GUID=mocked_settings):
+        response = client.get('/api')
+        assert response.get('Access-Control-Expose-Headers')
 
-    monkeypatch.setattr(guid_settings, 'EXPOSE_HEADER', True)
-    response = client.get('/api')
-    assert response.get('Access-Control-Expose-Headers')
 
-
-def test_no_expose_header_return_header_false(client, monkeypatch, mock_uuid):
+def test_no_expose_header_return_header_false(client):
     """
     Tests that it does not return the Access-Control-Allow-Origin when EXPOSE_HEADER is set to False
     and RETURN_HEADER is False
     """
-    from django_guid.config import settings as guid_settings
+    mocked_settings = django_settings.DJANGO_GUID
+    mocked_settings['EXPOSE_HEADER'] = False
+    mocked_settings['RETURN_HEADER'] = False
+    with override_settings(DJANGO_GUID=mocked_settings):
+        response = client.get('/api')
+        assert not response.get('Access-Control-Expose-Headers')
 
-    monkeypatch.setattr(guid_settings, 'EXPOSE_HEADER', False)
-    monkeypatch.setattr(guid_settings, 'RETURN_HEADER', False)
-    response = client.get('/api')
-    assert not response.get('Access-Control-Expose-Headers')
 
-
-def test_expose_header_return_header_false(client, monkeypatch, mock_uuid):
+def test_expose_header_return_header_false(client):
     """
     Tests that it does not return the Access-Control-Allow-Origin when EXPOSE_HEADER is set to True
     and RETURN_HEADER is False
     """
-    from django_guid.config import settings as guid_settings
+    mocked_settings = django_settings.DJANGO_GUID
+    mocked_settings['EXPOSE_HEADER'] = True
+    mocked_settings['RETURN_HEADER'] = False
+    with override_settings(DJANGO_GUID=mocked_settings):
+        response = client.get('/api')
+        assert not response.get('Access-Control-Expose-Headers')
 
-    monkeypatch.setattr(guid_settings, 'EXPOSE_HEADER', True)
-    monkeypatch.setattr(guid_settings, 'RETURN_HEADER', False)
-    response = client.get('/api')
-    assert not response.get('Access-Control-Expose-Headers')
 
-
-def test_cleanup_signal(client, caplog, monkeypatch):
+def test_cleanup_signal(client, caplog):
     """
     Tests that a request cleans up a request after finishing.
     :param client: Django client
     :param caplog: Caplog fixture
     :param monkeypatch: Monkeypatch for django settings
     """
-    from django_guid.config import settings as guid_settings
+    mocked_settings = django_settings.DJANGO_GUID
+    mocked_settings['VALIDATE_GUID'] = False
+    with override_settings(DJANGO_GUID=mocked_settings):
+        client.get('/', **{'HTTP_Correlation-ID': 'bad-guid'})
+        client.get('/', **{'HTTP_Correlation-ID': 'another-bad-guid'})
 
-    monkeypatch.setattr(guid_settings, 'VALIDATE_GUID', False)
-    client.get('/', **{'HTTP_Correlation-ID': 'bad-guid'})
-    client.get('/', **{'HTTP_Correlation-ID': 'another-bad-guid'})
-
-    expected = [
-        # First request
-        ('sync middleware called', None),
-        ('Correlation-ID found in the header: bad-guid', None),
-        ('Returning ID from header without validating it as a GUID', None),
-        ('This log message should have a GUID', 'bad-guid'),
-        ('Some warning in a function', 'bad-guid'),
-        ('Received signal `request_finished`, clearing guid', 'bad-guid'),
-        # Second request
-        ('sync middleware called', None),
-        ('Correlation-ID found in the header: another-bad-guid', None),
-        ('Returning ID from header without validating it as a GUID', None),
-        ('This log message should have a GUID', 'another-bad-guid'),
-        ('Some warning in a function', 'another-bad-guid'),
-        ('Received signal `request_finished`, clearing guid', 'another-bad-guid'),
-    ]
-    assert [(x.message, x.correlation_id) for x in caplog.records] == expected
+        expected = [
+            # First request
+            ('sync middleware called', None),
+            ('Correlation-ID found in the header: bad-guid', None),
+            ('Returning ID from header without validating it as a GUID', None),
+            ('This log message should have a GUID', 'bad-guid'),
+            ('Some warning in a function', 'bad-guid'),
+            ('Received signal `request_finished`, clearing guid', 'bad-guid'),
+            # Second request
+            ('sync middleware called', None),
+            ('Correlation-ID found in the header: another-bad-guid', None),
+            ('Returning ID from header without validating it as a GUID', None),
+            ('This log message should have a GUID', 'another-bad-guid'),
+            ('Some warning in a function', 'another-bad-guid'),
+            ('Received signal `request_finished`, clearing guid', 'another-bad-guid'),
+        ]
+        assert [(x.message, x.correlation_id) for x in caplog.records] == expected
 
 
 def test_improperly_configured_if_not_in_installed_apps(client, monkeypatch):
@@ -205,22 +209,21 @@ def test_improperly_configured_if_not_in_installed_apps(client, monkeypatch):
         client.get('/')
 
 
-def test_url_ignored(client, caplog, monkeypatch):
+def test_url_ignored(client, caplog):
     """
     Test that a URL specified in IGNORE_URLS is ignored.
     :param client: Django client
     :param caplog: Caplog fixture
-    :param monkeypatch: Monkeypatch for django settings
     """
-    from django_guid.config import settings as guid_settings
-
-    monkeypatch.setattr(guid_settings, 'IGNORE_URLS', {'no-guid'})  # Same as it would be after config conversion
-    client.get('/no-guid', **{'HTTP_Correlation-ID': 'bad-guid'})
-    # No log message should have a GUID, aka `None` on index 1.
-    expected = [
-        ('sync middleware called', None),
-        ('This log message should NOT have a GUID - the URL is in IGNORE_URLS', None),
-        ('Some warning in a function', None),
-        ('Received signal `request_finished`, clearing guid', None),
-    ]
-    assert [(x.message, x.correlation_id) for x in caplog.records] == expected
+    mocked_settings = django_settings.DJANGO_GUID
+    mocked_settings['IGNORE_URLS'] = {'no-guid'}
+    with override_settings(DJANGO_GUID=mocked_settings):
+        client.get('/no-guid', **{'HTTP_Correlation-ID': 'bad-guid'})
+        # No log message should have a GUID, aka `None` on index 1.
+        expected = [
+            ('sync middleware called', None),
+            ('This log message should NOT have a GUID - the URL is in IGNORE_URLS', None),
+            ('Some warning in a function', None),
+            ('Received signal `request_finished`, clearing guid', None),
+        ]
+        assert [(x.message, x.correlation_id) for x in caplog.records] == expected

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -9,6 +9,12 @@ import pytest
 from django_guid.config import Settings
 
 
+@override_settings()
+def test_no_config(settings):
+    del settings.DJANGO_GUID
+    Settings().validate()
+
+
 def test_invalid_guid():
     mocked_settings = deepcopy(django_settings.DJANGO_GUID)
     mocked_settings['VALIDATE_GUID'] = 'string'
@@ -77,6 +83,15 @@ def test_not_string_in_igore_urls():
         mocked_settings['IGNORE_URLS'] = setting
         with override_settings(DJANGO_GUID=mocked_settings):
             with pytest.raises(ImproperlyConfigured, match='IGNORE_URLS must be an array of strings'):
+                Settings().validate()
+
+
+def test_uuid_len_fail():
+    for setting in [True, False, {}, [], 'asd', -1, 0, 33]:
+        mocked_settings = deepcopy(django_settings.DJANGO_GUID)
+        mocked_settings['UUID_LENGTH'] = setting
+        with override_settings(DJANGO_GUID=mocked_settings):
+            with pytest.raises(ImproperlyConfigured, match='UUID_LENGTH must be an integer and be between 1-32'):
                 Settings().validate()
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,79 +1,88 @@
+from copy import deepcopy
+
 from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
 
 import pytest
 
 from django_guid.config import Settings
 
 
-def test_invalid_setting(monkeypatch):
-    monkeypatch.setattr(django_settings, 'DJANGO_GUID', {'invalid_setting': 'some_value'})
-    with pytest.raises(ImproperlyConfigured, match='invalid_setting is not a valid setting for django_guid'):
-        Settings()
+def test_invalid_guid():
+    mocked_settings = deepcopy(django_settings.DJANGO_GUID)
+    mocked_settings['VALIDATE_GUID'] = 'string'
+    with override_settings(DJANGO_GUID=mocked_settings):
+        with pytest.raises(ImproperlyConfigured, match='VALIDATE_GUID must be a boolean'):
+            Settings().validate()
 
 
-def test_invalid_guid(monkeypatch):
-    monkeypatch.setattr(django_settings, 'DJANGO_GUID', {'VALIDATE_GUID': 'string'})
-    with pytest.raises(ImproperlyConfigured, match='VALIDATE_GUID must be a boolean'):
-        Settings()
+def test_invalid_header_name():
+    mocked_settings = deepcopy(django_settings.DJANGO_GUID)
+    mocked_settings['GUID_HEADER_NAME'] = True
+    with override_settings(DJANGO_GUID=mocked_settings):
+        with pytest.raises(ImproperlyConfigured, match='GUID_HEADER_NAME must be a string'):
+            Settings().validate()
 
 
-def test_invalid_header_name(monkeypatch):
-    monkeypatch.setattr(django_settings, 'DJANGO_GUID', {'GUID_HEADER_NAME': True})
-    with pytest.raises(ImproperlyConfigured, match='GUID_HEADER_NAME must be a string'):
-        Settings()
+def test_invalid_return_header_setting():
+    mocked_settings = deepcopy(django_settings.DJANGO_GUID)
+    mocked_settings['RETURN_HEADER'] = 'string'
+    with override_settings(DJANGO_GUID=mocked_settings):
+        with pytest.raises(ImproperlyConfigured, match='RETURN_HEADER must be a boolean'):
+            Settings().validate()
 
 
-def test_invalid_return_header_setting(monkeypatch):
-    monkeypatch.setattr(django_settings, 'DJANGO_GUID', {'RETURN_HEADER': 'string'})
-    with pytest.raises(ImproperlyConfigured, match='RETURN_HEADER must be a boolean'):
-        Settings()
+def test_invalid_expose_header_setting():
+    mocked_settings = deepcopy(django_settings.DJANGO_GUID)
+    mocked_settings['EXPOSE_HEADER'] = 'string'
+    with override_settings(DJANGO_GUID=mocked_settings):
+        with pytest.raises(ImproperlyConfigured, match='EXPOSE_HEADER must be a boolean'):
+            Settings().validate()
 
 
-def test_invalid_expose_header_setting(monkeypatch):
-    monkeypatch.setattr(django_settings, 'DJANGO_GUID', {'EXPOSE_HEADER': 'string'})
-    with pytest.raises(ImproperlyConfigured, match='EXPOSE_HEADER must be a boolean'):
-        Settings()
+def test_valid_settings():
+    mocked_settings = deepcopy(django_settings.DJANGO_GUID)
+    mocked_settings['VALIDATE_GUID'] = False
+    mocked_settings['GUID_HEADER_NAME'] = 'Correlation-ID-TEST'
+    mocked_settings['RETURN_HEADER'] = False
+    mocked_settings['EXPOSE_HEADER'] = False
+    with override_settings(DJANGO_GUID=mocked_settings):
+        assert not Settings().validate_guid
+        assert Settings().guid_header_name == 'Correlation-ID-TEST'
+        assert not Settings().return_header
 
 
-def test_valid_settings(monkeypatch):
-    monkeypatch.setattr(
-        django_settings,
-        'DJANGO_GUID',
-        {
-            'VALIDATE_GUID': False,
-            'GUID_HEADER_NAME': 'Correlation-ID-TEST',
-            'RETURN_HEADER': False,
-            'EXPOSE_HEADER': False,
-        },
-    )
-    assert not Settings().VALIDATE_GUID
-    assert Settings().GUID_HEADER_NAME == 'Correlation-ID-TEST'
-    assert not Settings().RETURN_HEADER
-
-
-def test_bad_integrations_type(monkeypatch):
+def test_bad_integrations_type():
     for setting in [{}, '', 2, None, -2]:
-        monkeypatch.setattr(django_settings, 'DJANGO_GUID', {'INTEGRATIONS': setting})
-        with pytest.raises(ImproperlyConfigured, match='INTEGRATIONS must be an array'):
-            Settings()
+        mocked_settings = deepcopy(django_settings.DJANGO_GUID)
+        mocked_settings['INTEGRATIONS'] = setting
+        with override_settings(DJANGO_GUID=mocked_settings):
+            with pytest.raises(ImproperlyConfigured, match='INTEGRATIONS must be an array'):
+                Settings().validate()
 
 
-def test_not_array_ignore_urls(monkeypatch):
+def test_not_array_ignore_urls():
     for setting in [{}, '', 2, None, -2]:
-        monkeypatch.setattr(django_settings, 'DJANGO_GUID', {'IGNORE_URLS': setting})
-        with pytest.raises(ImproperlyConfigured, match='IGNORE_URLS must be an array'):
-            Settings()
+        mocked_settings = deepcopy(django_settings.DJANGO_GUID)
+        mocked_settings['IGNORE_URLS'] = setting
+        with override_settings(DJANGO_GUID=mocked_settings):
+            with pytest.raises(ImproperlyConfigured, match='IGNORE_URLS must be an array'):
+                Settings().validate()
 
 
 def test_not_string_in_igore_urls(monkeypatch):
-    for setting in (['api/v1/test', 'api/v1/othertest', True], [1, 2, 'yup']):
-        monkeypatch.setattr(django_settings, 'DJANGO_GUID', {'IGNORE_URLS': setting})
-        with pytest.raises(ImproperlyConfigured, match='IGNORE_URLS must be an array of strings'):
-            Settings()
+    for setting in ['api/v1/test', 'api/v1/othertest', True], [1, 2, 'yup']:
+        mocked_settings = deepcopy(django_settings.DJANGO_GUID)
+        mocked_settings['IGNORE_URLS'] = setting
+        with override_settings(DJANGO_GUID=mocked_settings):
+            with pytest.raises(ImproperlyConfigured, match='IGNORE_URLS must be an array of strings'):
+                Settings().validate()
 
 
 def test_converts_correctly(monkeypatch):
-    monkeypatch.setattr(django_settings, 'DJANGO_GUID', {'IGNORE_URLS': ['/no-guid', '/my/api/path/']})
-    assert 'my/api/path' in Settings().IGNORE_URLS
-    assert 'no-guid' in Settings().IGNORE_URLS
+    mocked_settings = deepcopy(django_settings.DJANGO_GUID)
+    mocked_settings['IGNORE_URLS'] = ['/no-guid', '/my/api/path/']
+    with override_settings(DJANGO_GUID=mocked_settings):
+        assert 'my/api/path' in Settings().ignore_urls
+        assert 'no-guid' in Settings().ignore_urls

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -71,7 +71,7 @@ def test_not_array_ignore_urls():
                 Settings().validate()
 
 
-def test_not_string_in_igore_urls(monkeypatch):
+def test_not_string_in_igore_urls():
     for setting in ['api/v1/test', 'api/v1/othertest', True], [1, 2, 'yup']:
         mocked_settings = deepcopy(django_settings.DJANGO_GUID)
         mocked_settings['IGNORE_URLS'] = setting
@@ -80,7 +80,7 @@ def test_not_string_in_igore_urls(monkeypatch):
                 Settings().validate()
 
 
-def test_converts_correctly(monkeypatch):
+def test_converts_correctly():
     mocked_settings = deepcopy(django_settings.DJANGO_GUID)
     mocked_settings['IGNORE_URLS'] = ['/no-guid', '/my/api/path/']
     with override_settings(DJANGO_GUID=mocked_settings):

--- a/tests/unit/test_uuid_length.py
+++ b/tests/unit/test_uuid_length.py
@@ -1,0 +1,25 @@
+from django.conf import settings as django_settings
+from django.test import override_settings
+
+from django_guid.utils import generate_guid
+
+
+def test_uuid_length():
+    """
+    Make sure passing uuid_length works.
+    """
+    for i in range(0, 33):
+        guid = generate_guid(uuid_length=i)
+        assert len(guid) == i
+
+
+def test_uuid_length_setting():
+    """
+    Make sure that the settings value is used as a default.
+    """
+    for i in range(0, 33):
+        mocked_settings = django_settings.DJANGO_GUID
+        mocked_settings['UUID_LENGTH'] = i
+        with override_settings(DJANGO_GUID=mocked_settings):
+            guid = generate_guid()
+            assert len(guid) == i

--- a/tests/unit/test_uuid_length.py
+++ b/tests/unit/test_uuid_length.py
@@ -8,7 +8,7 @@ def test_uuid_length():
     """
     Make sure passing uuid_length works.
     """
-    for i in range(0, 33):
+    for i in range(33):
         guid = generate_guid(uuid_length=i)
         assert len(guid) == i
 
@@ -17,7 +17,7 @@ def test_uuid_length_setting():
     """
     Make sure that the settings value is used as a default.
     """
-    for i in range(0, 33):
+    for i in range(33):
         mocked_settings = django_settings.DJANGO_GUID
         mocked_settings['UUID_LENGTH'] = i
         with override_settings(DJANGO_GUID=mocked_settings):


### PR DESCRIPTION
PR for settings rework. Splits out that part of #48 to simplify reviewing, and to make tests pass in isolation from all the celery changes.

#### Changes

1. Adds a `UUID_LENGTH` optional setting (this will also be applied in the CeleryIntegration)
2. Makes settings lazy, and runs settings validation in the `appConfig` ready method so that any bad settings raise errors after the Django app is initialized. This should also remove all issues concerning import circularity (hopefully).
3. Adds the skeleton for `IntegrationSettings`