### PR TITLE
Upgrade django badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@
           <img src="https://img.shields.io/badge/python-3.7+-blue.svg" alt="Downloads">
       </a>
       <a href="https://pypi.python.org/pypi/django-guid">
-          <img src="https://img.shields.io/badge/django-2.2%20|%203.0%20|%203.1%20-blue.svg" alt="Django versions">
+          <img src="https://img.shields.io/pypi/djversions/django-guid?color=0C4B33&logo=django&logoColor=white&label=django" alt="Django versions">
       </a>
       </a>
       <a href="https://img.shields.io/badge/ASGI-supported-brightgreen.svg">


### PR DESCRIPTION
Saw this Django badge [here](https://github.com/fabiocaccamo/django-treenode/blob/master/README.md) 🚀

Looks better imo; what do you think?
<br>
For convenience:

**Old**
![image](https://user-images.githubusercontent.com/25310870/118810120-c93bf400-b8ab-11eb-94e5-7d766cec593e.png)


**New** 
![image](https://user-images.githubusercontent.com/25310870/118810134-cfca6b80-b8ab-11eb-83ee-8a79c2e2fa32.png)

No label is also possible: https://img.shields.io/pypi/djversions/django-guid?color=0C4B33&logo=django&logoColor=white&label=