### PR TITLE
Conditionally use deprecated default_app_config

### DIFF
--- a/django_guid/__init__.py
+++ b/django_guid/__init__.py
@@ -1,6 +1,10 @@
+import django
+
 from django_guid.api import clear_guid, get_guid, set_guid  # noqa F401
 
 __version__ = '3.2.1'
-default_app_config = 'django_guid.apps.DjangoGuidConfig'
+
+if django.VERSION < (3, 2):
+    default_app_config = 'django_guid.apps.DjangoGuidConfig'
 
 __all__ = ['clear_guid', 'get_guid', 'set_guid']


### PR DESCRIPTION
`default_app_config` is being removed in Django 4.1 and a new warning has shown up since django 3.2

https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-4-1