### PR TITLE
Fix documentation for UUID_FORMAT setting

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -83,11 +83,11 @@ If a full UUID hex is too long for you, this settings lets you specify the lengt
 The chance of collision in a UUID is so low, that most systems will get away with a lot
 fewer than 32 characters.
 
-UUID_LENGTH
+UUID_FORMAT
 -----------
 * **Default**: ``hex``
 * **Type**: ``string``
 
 If a UUID hex is not suitable for you, this settings lets you specify the format you wish to use. The options are:
 * ``hex``: The default, a 32 character hexadecimal string. e.g. ee586b0fba3c44849d20e1548210c050
-* ``str``: A 36 character string. e.g. ee586b0f-ba3c-4484-9d20-e1548210c050
+* ``string``: A 36 character string. e.g. ee586b0f-ba3c-4484-9d20-e1548210c050


### PR DESCRIPTION
Looks like a simple copy-n-paste error ;)

Keeping it consistent with code and tests in:
* https://github.com/snok/django-guid/blob/main/django_guid/config.py#L67
* https://github.com/snok/django-guid/blob/main/django_guid/config.py#L86-L91
* https://github.com/snok/django-guid/blob/main/tests/functional/test_sync_middleware.py#L11-L24
* https://github.com/snok/django-guid/blob/main/tests/functional/test_sync_middleware.py#L45-L55
* https://github.com/snok/django-guid/blob/main/tests/functional/test_sync_middleware.py#L73-L83
* https://github.com/snok/django-guid/blob/main/tests/unit/test_config.py#L12-L13
* https://github.com/snok/django-guid/blob/main/tests/unit/test_config.py#L93-L120
* https://github.com/snok/django-guid/blob/main/tests/unit/test_uuid_length.py#L18-L24