### PR TITLE
Add the ability to customize the log record field name for correlation ids.

### DIFF
--- a/django_guid/log_filters.py
+++ b/django_guid/log_filters.py
@@ -8,15 +8,16 @@ if TYPE_CHECKING:
 
 
 class CorrelationId(Filter):
+    def __init__(self, correlation_id_field: str = 'correlation_id') -> None:
+        super().__init__()
+        self.correlation_id_field = correlation_id_field
+
     def filter(self, record: 'LogRecord') -> bool:
         """
-        Determines that the specified record is to be logged.
-
-        From the docs:
-                Is the specified record to be logged? Returns 0 for no, nonzero for
-                yes. If deemed appropriate, the record may be modified in-place.
+        Add the correlation ID to the log record.
         :param record: Log record
+        :param correlation_id_field: record field on which the correlation id is set
         :return: True
         """
-        record.correlation_id = guid.get()
+        setattr(record, self.correlation_id_field, guid.get())
         return True

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -45,7 +45,9 @@ Add :code:`django_guid.log_filters.CorrelationId` as a filter in your ``LOGGING`
         ...
         'filters': {
             'correlation_id': {
-                '()': 'django_guid.log_filters.CorrelationId'
+                '()': 'django_guid.log_filters.CorrelationId',
+                # You can optionally override the record field name where the guid is stored
+                'correlation_id_field': 'correlation_id'
             }
         }
     }

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -36,8 +36,9 @@ VALIDATE_GUID
 * **Type**: ``boolean``
 
 
-Whether the :code:`GUID_HEADER_NAME` should be validated or not.
-If the GUID sent to through the header is not a valid GUID (:code:`uuid.uuid4`).
+Whether the :code:`GUID_HEADER_NAME` should be validated or not. If set to :code:`True`
+incoming headers which are not a valid GUID (:code:`uuid.uuid4`), will be replaced with
+a new one.
 
 
 RETURN_HEADER


### PR DESCRIPTION
# Motivation

I use elastic common schema for the logs of my django application (with `ecs-logging`). ECS dictates the use of `http.request.id` as the field name for request ids. At the moment I use an an additional filter that moves the field form `correlation_id` to `http.request.id`, but I figured it is much cleaner to choose the field name here and other people might also find this usefull. Very neat package btw, thx!

