### PR TITLE
[BUG] Sentry scope migration fo 2.x

### DIFF
--- a/django_guid/integrations/sentry.py
+++ b/django_guid/integrations/sentry.py
@@ -34,6 +34,6 @@ class SentryIntegration(Integration):
         """
         import sentry_sdk
 
-        with sentry_sdk.configure_scope() as scope:
-            logger.debug('Setting Sentry transaction_id to %s', guid)
-            scope.set_tag('transaction_id', guid)
+        scope = sentry_sdk.get_isolation_scope()
+        logger.debug('Setting Sentry transaction_id to %s', guid)
+        scope.set_tag('transaction_id', guid)


### PR DESCRIPTION
migrate scope usage to v2.x
more info https://docs.sentry.io/platforms/python/migration/1.x-to-2.x#scope-configuring