### PR TITLE
fix: import guid context var from context module

### DIFF
--- a/django_guid/log_filters.py
+++ b/django_guid/log_filters.py
@@ -1,7 +1,7 @@
 from logging import Filter
 from typing import TYPE_CHECKING
 
-from django_guid.middleware import guid
+from django_guid.context import guid
 
 if TYPE_CHECKING:
     from logging import LogRecord

--- a/django_guid/signals.py
+++ b/django_guid/signals.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 from django.core.signals import request_finished
 from django.dispatch import receiver
 
-from django_guid.middleware import guid
+from django_guid.context import guid
 
 logger = logging.getLogger('django_guid')
 


### PR DESCRIPTION
This fixes two problems:

1. Some tools complain that `django_guid.middleware` do not export `guid` symbol
2. Importing from `django_guid.middleware` requires Django to be initialized. Importing from `django_guid.context` does not. This is useful to add the `CorrelationId` to Gunicorn access logs.