### PR TITLE
feat: add support for sentry>2 Celery integration

### DIFF
--- a/django_guid/integrations/celery/signals.py
+++ b/django_guid/integrations/celery/signals.py
@@ -21,11 +21,16 @@ def set_transaction_id(guid: str) -> None:
     Sets the Sentry transaction ID if the Celery sentry integration setting is True.
     """
     if settings.integration_settings.celery.sentry_integration:
-        from sentry_sdk import configure_scope
+        import sentry_sdk
 
-        with configure_scope() as scope:
-            logger.debug('Setting Sentry transaction_id to %s', guid)
-            scope.set_tag('transaction_id', guid)
+        if sentry_sdk.VERSION >= '2.0.0':
+            with sentry_sdk.isolation_scope() as scope:
+                scope.set_tag('transaction_id', guid)
+        else:
+            with sentry_sdk.configure_scope() as scope:
+                scope.set_tag('transaction_id', guid)
+
+        logger.debug('Setting Sentry transaction_id to %s', guid)
 
 
 @before_task_publish.connect

--- a/django_guid/integrations/celery/signals.py
+++ b/django_guid/integrations/celery/signals.py
@@ -22,8 +22,9 @@ def set_transaction_id(guid: str) -> None:
     """
     if settings.integration_settings.celery.sentry_integration:
         import sentry_sdk
+        from packaging import version
 
-        if sentry_sdk.VERSION >= '2.0.0':
+        if version.parse(sentry_sdk.VERSION) >= version.parse('2.12.0'):
             with sentry_sdk.isolation_scope() as scope:
                 scope.set_tag('transaction_id', guid)
         else:

--- a/django_guid/integrations/sentry.py
+++ b/django_guid/integrations/sentry.py
@@ -33,8 +33,9 @@ class SentryIntegration(Integration):
         Sets the Sentry transaction_id.
         """
         import sentry_sdk
+        from packaging import version
 
-        if sentry_sdk.VERSION >= '2.0.0':
+        if version.parse(sentry_sdk.VERSION) >= version.parse('2.12.0'):
             with sentry_sdk.isolation_scope() as scope:
                 scope.set_tag('transaction_id', guid)
         else:

--- a/django_guid/integrations/sentry.py
+++ b/django_guid/integrations/sentry.py
@@ -41,4 +41,4 @@ class SentryIntegration(Integration):
             with sentry_sdk.configure_scope() as scope:
                 scope.set_tag('transaction_id', guid)
 
-        logger.debug(f'Setting Sentry transaction_id to {guid}')
+        logger.debug('Setting Sentry transaction_id to %s', guid)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1393,4 +1393,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "c993f881929f1f3d0185d9ae99a48dbf62fc16b407f028bfa79d0fa38cc10f12"
+content-hash = "76b4aabd905289ff71ca5414e2b31566501c49ee136643f500e93af1c7583a78"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ django = [
     { version = "^4.0", python = ">=3.8,<3.10" },
     { version = "^4.0 | ^5.0", python = ">=3.10" }
 ]
+packaging = "*"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Applies the same Sentry v2 scope from #129 changes to the Celery Sentry integration

Followup to #129