### PR TITLE
tests: make use of incorporated Pytest subtests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,13 @@ coverage = {extras = ["toml"], version = "^6.5.0"}
 pre-commit = "^2.9"
 sphinx = "^2.4.4"
 sphinx_rtd_theme = "^0.4.3"
-pytest = "^8.3.2"
+pytest = [
+    { version = "^8.3.2", python = "<3.10" },
+    { version = "^9", python = ">=3.10" },
+]
 pytest-django = "^4.9.0"
 pytest-mock = "^3"
-pytest-subtests = "^0.13"
+pytest-subtests = { version = "^0.13", python = "<3.10" }
 djangorestframework = "^3.15.0"
 sentry-sdk = ">=0.14.3,<2.9.0"
 gunicorn = "^23.0.0"


### PR DESCRIPTION
https://github.com/pytest-dev/pytest-subtests?tab=readme-ov-file#important

> This plugin has been integrated directly into pytest 9.0, so the
  plugin itself will no longer be maintained and the repository will be
  archived.

Fixes: https://github.com/snok/django-guid/issues/156