### PR TITLE
chore: bump version to 3.6.1

### DIFF
--- a/django_guid/__init__.py
+++ b/django_guid/__init__.py
@@ -2,7 +2,7 @@ import django
 
 from django_guid.api import clear_guid, get_guid, set_guid  # noqa F401
 
-__version__ = '3.5.2'
+__version__ = '3.6.1'
 
 if django.VERSION < (3, 2):
     default_app_config = 'django_guid.apps.DjangoGuidConfig'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-guid"
-version = "3.5.2"  # Remember to also change __init__.py version
+version = "3.6.1"  # Remember to also change __init__.py version
 description = "Middleware that enables single request-response cycle tracing by injecting a unique ID into project logs"
 authors = ["Jonas Krüger Svensson <jonas-ks@hotmail.com>"]
 maintainers = ["Sondre Lillebø Gundersen <sondrelg@live.no>"]


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` and `django_guid/__init__.py` from `3.5.2` to `3.6.1`.

## Why
The 3.6.0 GitHub release tag was cut on 2026-05-01 (Django 6 support, #158), but the version files were never bumped from `3.5.2`, so the package was not published to PyPI. Bumping to `3.6.1` to publish the Django 6 support work as a fresh release.

## Test plan
- [ ] CI passes
- [ ] After merge, cut a new GitHub release `3.6.1` so the publish workflow runs against the bumped version

🤖 Generated with [Claude Code](https://claude.com/claude-code)